### PR TITLE
Fix typo in `ServiceBinding.Volumes_from`

### DIFF
--- a/dockercloud/type.go
+++ b/dockercloud/type.go
@@ -406,7 +406,7 @@ type ServiceBinding struct {
 	Container_path string `json:"container_path"`
 	Host_path      string `json:"host_path"`
 	Rewritable     bool   `json:"rewritable"`
-	Volumes_from   string `json:"volume_from"`
+	Volumes_from   string `json:"volumes_from"`
 }
 
 type ServiceCreateRequest struct {


### PR DESCRIPTION
Without this fix, created services are not able to mount volumes from other containers