### PR TITLE
Do not send from_service in JSON payload as the API will reject the request

### DIFF
--- a/dockercloud/type.go
+++ b/dockercloud/type.go
@@ -433,7 +433,7 @@ type ServiceCreateRequest struct {
 }
 
 type ServiceLinkInfo struct {
-	From_service string `json:"from_service"`
+	From_service string `json:"from_service,omitempty"`
 	Name         string `json:"name"`
 	To_service   string `json:"to_service"`
 }


### PR DESCRIPTION
The API docs do not include support for the "from_service" field, so adding a `ServiceLink` to the `ServiceCreateRequest` causes the request to return 400.