### PR TITLE
Omitempty on binding

### DIFF
--- a/dockercloud/type.go
+++ b/dockercloud/type.go
@@ -278,7 +278,7 @@ type NodeCluster struct {
 	Name               string         `json:"name"`
 	Nodes              []string       `json:"nodes"`
 	NodeType           string         `json:"node_type"`
-	Provider_options   ProviderOption `json:"provider_options,omitempty"`
+	Provider_options   ProviderOption `json:"provider_options"`
 	Region             string         `json:"region"`
 	Resource_uri       string         `json:"resource_uri"`
 	State              string         `json:"state"`

--- a/dockercloud/type.go
+++ b/dockercloud/type.go
@@ -273,7 +273,7 @@ type NodeCluster struct {
 	Name               string         `json:"name"`
 	Nodes              []string       `json:"nodes"`
 	NodeType           string         `json:"node_type"`
-	Provider_options   ProviderOption `json:"provider_options"`
+	Provider_options   ProviderOption `json:"provider_options,omitempty"`
 	Region             string         `json:"region"`
 	Resource_uri       string         `json:"resource_uri"`
 	State              string         `json:"state"`
@@ -283,12 +283,13 @@ type NodeCluster struct {
 }
 
 type NodeCreateRequest struct {
-	Disk             int       `json:"disk,omitempty"`
-	Name             string    `json:"name,omitempty"`
-	NodeType         string    `json:"node_type,omitempty"`
-	Region           string    `json:"region,omitempty"`
-	Target_num_nodes int       `json:"target_num_nodes,omitempty"`
-	Tags             []NodeTag `json:"tags,omitempty"`
+	Disk             int            `json:"disk,omitempty"`
+	Name             string         `json:"name,omitempty"`
+	NodeType         string         `json:"node_type,omitempty"`
+	Provider_options ProviderOption `json:"provider_options"`
+	Region           string         `json:"region,omitempty"`
+	Target_num_nodes int            `json:"target_num_nodes,omitempty"`
+	Tags             []NodeTag      `json:"tags,omitempty"`
 }
 
 type NodeTypeListResponse struct {

--- a/dockercloud/type.go
+++ b/dockercloud/type.go
@@ -404,10 +404,10 @@ type Service struct {
 }
 
 type ServiceBinding struct {
-	Container_path string `json:"container_path"`
+	Container_path string `json:"container_path,omitempty"`
 	Host_path      string `json:"host_path"`
 	Rewritable     bool   `json:"rewritable"`
-	Volumes_from   string `json:"volume_from"`
+	Volumes_from   string `json:"volume_from,omitempty"`
 }
 
 type ServiceCreateRequest struct {


### PR DESCRIPTION
Since _either_ `Container_path` or `Volumes_from` is required, they'll need `omitempty