### PR TITLE
If Debug then show message returned from api

### DIFF
--- a/dockercloud/error.go
+++ b/dockercloud/error.go
@@ -7,8 +7,13 @@ import (
 type HttpError struct {
 	Status     string
 	StatusCode int
+	Message    []byte
 }
 
 func (e HttpError) Error() string {
+	if Debug == true {
+		return fmt.Sprintf("Failed API call: %s Message: %s", e.Status, e.Message)
+	}
+
 	return fmt.Sprintf("Failed API call: %s", e.Status)
 }

--- a/dockercloud/http.go
+++ b/dockercloud/http.go
@@ -66,11 +66,7 @@ func DockerCloudCall(url string, requestType string, requestBody []byte) ([]byte
 	}
 
 	if response.StatusCode > 300 {
-		if Debug == true {
-			return nil, HttpError{Status: response.Status, StatusCode: response.StatusCode, Message: data}
-		}
-
-		return nil, HttpError{Status: response.Status, StatusCode: response.StatusCode}
+		return nil, HttpError{Status: response.Status, StatusCode: response.StatusCode, Message: data}
 	}
 
 	if Debug == true {

--- a/dockercloud/http.go
+++ b/dockercloud/http.go
@@ -57,16 +57,20 @@ func DockerCloudCall(url string, requestType string, requestBody []byte) ([]byte
 		return nil, err
 	}
 
-	if response.StatusCode > 300 {
-		return nil, HttpError{Status: response.Status, StatusCode: response.StatusCode}
-	}
-
 	DCJar.SetCookies(req.URL, response.Cookies())
 
 	data, err := ioutil.ReadAll(response.Body)
 
 	if err != nil {
 		return nil, err
+	}
+
+	if response.StatusCode > 300 {
+		if Debug == true {
+			return nil, HttpError{Status: response.Status, StatusCode: response.StatusCode, Message: data}
+		}
+
+		return nil, HttpError{Status: response.Status, StatusCode: response.StatusCode}
 	}
 
 	if Debug == true {


### PR DESCRIPTION
Closes #49 

This could probably be done better.  I'm not super familiar with all the different types of responses for statusCode's > 300.  This at the very least gives insight into what it was the server said was wrong with the request when trying to debug.

Before:
```
2016/12/20 18:03:50 Failed API call: 409 CONFLICT
```

After:
```
2016/12/20 18:04:18 Failed API call: 409 CONFLICT Message: {"error": "Duplicated name 'bestever4'. There is another service with the same name that does not belong to any stack."}
```